### PR TITLE
Fix Bioc JSON OffsetWriter TypeError

### DIFF
--- a/bconv/fmt/bioc.py
+++ b/bconv/fmt/bioc.py
@@ -601,7 +601,8 @@ class OffsetWriter(_OffsetManager):
         """
         Calculate start and length of this annotation.
         """
-        return entity.start, entity.end-entity.start
+        for start, end in entity.offsets:
+            yield start, end-start
 
     # Aliases for backward compatibility.
     def passage(self, unit):

--- a/bconv/fmt/bioc.py
+++ b/bconv/fmt/bioc.py
@@ -601,7 +601,7 @@ class OffsetWriter(_OffsetManager):
         """
         Calculate start and length of this annotation.
         """
-        for start, end in entity.offsets:
+        for start, end in entity.spans:
             yield start, end-start
 
     # Aliases for backward compatibility.


### PR DESCRIPTION
Fixing the TyperError raised by Bioc JSON OffsetWriter by changing OffsetWriter entity() return to yield and iterating through the entity spans to handle discontinuous entities. 